### PR TITLE
Strict single-word capture of victim in parseHonorMessage

### DIFF
--- a/honorspy.lua
+++ b/honorspy.lua
@@ -134,7 +134,7 @@ end
 local function parseHonorMessage(msg)
 	local honor_gain_pattern = string.gsub(COMBATLOG_HONORGAIN, "%(", "%%(")
 	honor_gain_pattern = string.gsub(honor_gain_pattern, "%)", "%%)")
-	honor_gain_pattern = string.gsub(honor_gain_pattern, "(%%s)", "(.+)")
+	honor_gain_pattern = string.gsub(honor_gain_pattern, "(%%s)", "(%%w+)")
 	honor_gain_pattern = string.gsub(honor_gain_pattern, "(%%d)", "(%%d+)")
     local victim, rank, est_honor = msg:match(honor_gain_pattern)
     if (victim) then


### PR DESCRIPTION
Fixes a bug that would occur when another addon dirties the chat message output by `CHAT_MSG_COMBAT_HONOR_GAIN_EVENT`. HonorCounter currently prepends 'HonorCounter: ' to the message we expect in `parseHonorMessage(...)`. A greedy any-character match results in failure to parse the name of the victim, thus we always compute decay with 0 kills.

I believe this bug only affected the chat output. `CHAT_MSG_COMBAT_HONOR_GAIN_EVENT` should receive the untainted chat message as filters are executed by the chat frame's event handler.