### PR TITLE
v1.7.3: update diminishing honor return

### DIFF
--- a/honorspy.toc
+++ b/honorspy.toc
@@ -7,7 +7,7 @@
 
 ## Author: kakysha
 ## OptionalDeps: Ace3
-## Version: 1.7.2
+## Version: 1.7.3
 
 ## X-Category: Battlegrounds/PvP
 ## SavedVariables: HonorSpyDB


### PR DESCRIPTION
Blizzard announced change to the diminishing honor return factor for repeated kills.
https://us.forums.blizzard.com/en/wow/t/alterac-valley-adjustments-incoming/422125

This pull request creates a separate local function to compute the diminished value and extracts the factor into a constant variable. It corrects the factor to 0.1 from 0.25 of the original honor release.

Tested in game to correctly calculate the diminishing return exactly as before, with 10% reduction per repeated kill instead of 25%.