### PR TITLE
Extends exportCSV EditBox char length

### DIFF
--- a/export.lua
+++ b/export.lua
@@ -24,7 +24,7 @@ function HonorSpy:ExportCSV()
 		
 		local editBox = CreateFrame("EditBox", "ARLCopyEdit", frame)
 		editBox:SetMultiLine(true)
-		editBox:SetMaxLetters(99999)
+		editBox:SetMaxLetters(999999)
 		editBox:EnableMouse(true)
 		editBox:SetAutoFocus(false)
 		editBox:SetFontObject(ChatFontNormal)


### PR DESCRIPTION
Original size 99999 isnt enough for poolsize >1800, CSV got split.