### PR TITLE
Feature Add - Estimated Honor in Broadcast + Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# HonorSpy
+
+## [1.7.3](https://github.com/kakysha/HonorSpy/tree/1.7.3) (2020-01-30)
+[Full Changelog](https://github.com/kakysha/HonorSpy/compare/1.7.2...1.7.3)
+
+- 10% Diminishing Returns instead of 25%  
+    Fixed Kore reset time (Tue -> Thu)  
+- Update README.md  
+- updated README  

--- a/GUI.lua
+++ b/GUI.lua
@@ -100,6 +100,7 @@ function GUI:UpdateTableView()
 			brk_delim_inserted = true
 			button.Name:SetText(colorize(format(L["Bracket"] .. " %d", brackets[itemIndex]), "GREY"))
 			button.Honor:SetText();
+			button.EstHonor:SetText();
 			button.LstWkHonor:SetText();
 			button.Standing:SetText();
 			button.RP:SetText();
@@ -110,7 +111,7 @@ function GUI:UpdateTableView()
 			button:Show();
 		
 		elseif (itemIndex <= #rows) then
-			local name, class, thisWeekHonor, lastWeekHonor, standing, RP, rank, last_checked = unpack(rows[itemIndex])
+			local name, class, thisWeekHonor, estHonor, lastWeekHonor, standing, RP, rank, last_checked = unpack(rows[itemIndex])
 			local last_seen, last_seen_human = (GetServerTime() - last_checked), ""
 			if (last_seen/60/60/24 > 1) then
 				last_seen_human = ""..math.floor(last_seen/60/60/24)..L["d"]
@@ -124,6 +125,7 @@ function GUI:UpdateTableView()
 			button:SetID(itemIndex);
 			button.Name:SetText(colorize(itemIndex .. ')  ', "GREY") .. colorize(name, class));
 			button.Honor:SetText(colorize(thisWeekHonor, class));
+			button.EstHonor:SetText(colorize(estHonor, class));
 			button.LstWkHonor:SetText(colorize(lastWeekHonor, class));
 			button.Standing:SetText(colorize(standing, class));
 			button.RP:SetText(colorize(RP, class));
@@ -157,7 +159,7 @@ function GUI:PrepareGUI()
 	_G["HonorSpyGUI_MainFrame"] = mainFrame
 	tinsert(UISpecialFrames, "HonorSpyGUI_MainFrame")	-- allow ESC close
 	mainFrame:SetTitle(L["HonorSpy Standings"])
-	mainFrame:SetWidth(600)
+	mainFrame:SetWidth(680)
 	mainFrame:SetLayout("List")
 	mainFrame:EnableResize(false)
 
@@ -198,6 +200,15 @@ function GUI:PrepareGUI()
 	btn.highlight:SetColorTexture(0.3, 0.3, 0.3, 0.5)
 	btn:SetWidth(80)
 	btn:SetText(colorize(L["Honor"], "ORANGE"))
+	tableHeader:AddChild(btn)
+
+	btn = AceGUI:Create("InteractiveLabel")
+	btn:SetCallback("OnClick", function()
+		GUI:Show(false, L["EstHonor"])
+	end)
+	btn.highlight:SetColorTexture(0.3, 0.3, 0.3, 0.5)
+	btn:SetWidth(80)
+	btn:SetText(colorize(L["EstHonor"], "ORANGE"))
 	tableHeader:AddChild(btn)
 
 	btn = AceGUI:Create("InteractiveLabel")

--- a/GUI.lua
+++ b/GUI.lua
@@ -6,7 +6,7 @@ local L = LibStub("AceLocale-3.0"):GetLocale("HonorSpy", true)
 
 LibStub("AceHook-3.0"):Embed(GUI)
 
-local mainFrame, statusLine, playerStandings, reportBtn, scroll = nil, nil, nil, nil
+local mainFrame, poolSize, playerStandings, reportBtn, scroll = nil, nil, nil, nil
 local rows, brackets = {}, {}
 local playersPerRow = 50
 local needsRelayout = true
@@ -40,9 +40,19 @@ function GUI:Show(skipUpdate, sort_column)
 		end
 	end
 
-	local poolSizeText = format(L['Pool Size'] .. ': %d ', #rows)
-	statusLine:SetText('|cff777777/hs show|r                                                       ' .. poolSizeText .. '                                             |cff777777/hs search nickname|r')
-
+	local poolSizeText
+	
+	if tonumber(HonorSpy.db.factionrealm.poolBoost) > 0 then
+		poolSizeText = format(
+			L['Natural Pool Size'] .. ":" .. colorize(' %d', "RED") .. " - " .. 
+			L['Boosted Pool Size'] .. ":" .. colorize(' %d', "GREEN"), 
+			#rows, #rows + HonorSpy.db.factionrealm.poolBoost)
+	else
+		poolSizeText = format(
+			L['Pool Size'] .. ":" .. colorize(' %d', "ORANGE"),#rows)
+	end
+	poolSize:SetText(poolSizeText)
+	
 	local pool_size, standing, bracket, RP, EstRP, Rank, Progress, EstRank, EstProgress = HonorSpy:Estimate()
 	if (standing) then
 		local playerText = colorize(L['Progress of'], "GREY") .. ' ' .. colorize(playerName, HonorSpy.db.factionrealm.currentStandings[playerName].class)
@@ -100,7 +110,13 @@ function GUI:UpdateTableView()
 			brk_delim_inserted = true
 			button.Name:SetText(colorize(format(L["Bracket"] .. " %d", brackets[itemIndex]), "GREY"))
 			button.Honor:SetText();
-			button.EstHonor:SetText();
+			if HonorSpy.db.factionrealm.estHonorCol.show then
+				button.EstHonor:SetText();
+				button.EstHonor:SetWidth(80);
+			else
+				button.EstHonor:SetText();
+				button.EstHonor:SetWidth(0);
+			end
 			button.LstWkHonor:SetText();
 			button.Standing:SetText();
 			button.RP:SetText();
@@ -125,7 +141,13 @@ function GUI:UpdateTableView()
 			button:SetID(itemIndex);
 			button.Name:SetText(colorize(itemIndex .. ')  ', "GREY") .. colorize(name, class));
 			button.Honor:SetText(colorize(thisWeekHonor, class));
-			button.EstHonor:SetText(colorize(estHonor, class));
+			if HonorSpy.db.factionrealm.estHonorCol.show then 
+				button.EstHonor:SetText(colorize(estHonor, class)); 
+				button.EstHonor:SetWidth(80);
+			else 
+				button.EstHonor:SetText();
+				button.EstHonor:SetWidth(0);
+			end
 			button.LstWkHonor:SetText(colorize(lastWeekHonor, class));
 			button.Standing:SetText(colorize(standing, class));
 			button.RP:SetText(colorize(RP, class));
@@ -159,7 +181,7 @@ function GUI:PrepareGUI()
 	_G["HonorSpyGUI_MainFrame"] = mainFrame
 	tinsert(UISpecialFrames, "HonorSpyGUI_MainFrame")	-- allow ESC close
 	mainFrame:SetTitle(L["HonorSpy Standings"])
-	mainFrame:SetWidth(680)
+	if HonorSpy.db.factionrealm.estHonorCol.show then mainFrame:SetWidth(680) else mainFrame:SetWidth(600) end
 	mainFrame:SetLayout("List")
 	mainFrame:EnableResize(false)
 
@@ -202,14 +224,16 @@ function GUI:PrepareGUI()
 	btn:SetText(colorize(L["Honor"], "ORANGE"))
 	tableHeader:AddChild(btn)
 
-	btn = AceGUI:Create("InteractiveLabel")
-	btn:SetCallback("OnClick", function()
-		GUI:Show(false, L["EstHonor"])
-	end)
-	btn.highlight:SetColorTexture(0.3, 0.3, 0.3, 0.5)
-	btn:SetWidth(80)
-	btn:SetText(colorize(L["EstHonor"], "ORANGE"))
-	tableHeader:AddChild(btn)
+	if HonorSpy.db.factionrealm.estHonorCol.show then
+		btn = AceGUI:Create("InteractiveLabel")
+		btn:SetCallback("OnClick", function()
+			GUI:Show(false, L["EstHonor"])
+		end)
+		btn.highlight:SetColorTexture(0.3, 0.3, 0.3, 0.5)
+		btn:SetWidth(80)
+		btn:SetText(colorize(L["EstHonor"], "ORANGE"))
+		tableHeader:AddChild(btn)
+	end
 
 	btn = AceGUI:Create("InteractiveLabel")
 	btn:SetWidth(80)
@@ -244,7 +268,7 @@ function GUI:PrepareGUI()
 	btn:SetText(colorize(L["LastSeen"], "ORANGE"))
 	tableHeader:AddChild(btn)
 
-	scrollcontainer = AceGUI:Create("SimpleGroup")
+	local scrollcontainer = AceGUI:Create("SimpleGroup")
 	scrollcontainer:SetFullWidth(true)
 	scrollcontainer:SetHeight(390)
 	scrollcontainer:SetLayout("Fill")
@@ -258,11 +282,30 @@ function GUI:PrepareGUI()
 	HybridScrollFrame_SetDoNotHideScrollBar(scroll, true)
 	scroll.update = function() GUI:UpdateTableView() end
 
-	statusLine = AceGUI:Create("Label")
-	statusLine:SetFullWidth(true)
-	mainFrame:AddChild(statusLine)
-	statusLine:ClearAllPoints()
-	statusLine:SetPoint("BOTTOM", mainFrame.frame, "BOTTOM", 0, 15)
+	local hsFooter = AceGUI:Create("SimpleGroup")
+	mainFrame:AddChild(hsFooter)
+	hsFooter:SetWidth(mainFrame.frame:GetWidth() - 20)
+	hsFooter:SetLayout("Flow")
+
+	local hsShow = AceGUI:Create("Label")
+	hsShow:SetText('|cff777777/hs show|r')
+	hsShow:SetWidth(hsFooter.frame:GetWidth() / 4)
+	hsShow:SetPoint("BOTTOMLEFT")
+	hsShow:SetJustifyH("LEFT")
+	hsFooter:AddChild(hsShow)
+
+	poolSize = AceGUI:Create("Label")
+	poolSize:SetWidth(hsFooter.frame:GetWidth() / 2)
+	poolSize:SetPoint("BOTTOM")
+	poolSize:SetJustifyH("CENTER")
+	hsFooter:AddChild(poolSize)
+
+	local hsSearch = AceGUI:Create("Label")
+	hsSearch:SetWidth(hsFooter.frame:GetWidth() / 4)
+	hsSearch:SetPoint("BOTTOMRIGHT")
+	hsSearch:SetJustifyH("RIGHT")
+	hsSearch:SetText('|cff777777/hs search nickname|r')
+	hsFooter:AddChild(hsSearch)
 
 	if (not HonorSpyGUI:IsHooked(HonorFrame, "OnUpdate")) then
 		HonorSpyGUI:SecureHookScript(HonorFrame, "OnUpdate", "UpdateHonorFrameText")

--- a/HybridScrollFrame.xml
+++ b/HybridScrollFrame.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://www.blizzard.com/wow/ui/..\FrameXML\UI.xsd">
 
 	<Frame name="HybridScrollListItemTemplate" virtual="true">
-		<Size y="12" x="560"/>
+		<Size y="12" x="640"/>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<Texture parentKey="Background" setAllPoints="true">
@@ -20,10 +20,16 @@
 						<Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.Name"/>
 					</Anchors>
 				</FontString>
-				<FontString parentKey="LstWkHonor" inherits="GameFontHighlightSmall" justifyH="LEFT">
+				<FontString parentKey="EstHonor" inherits="GameFontHighlightSmall" justifyH="LEFT">
 					<Size x="80"/>
 					<Anchors>
 						<Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.Honor"/>
+					</Anchors>
+				</FontString>
+				<FontString parentKey="LstWkHonor" inherits="GameFontHighlightSmall" justifyH="LEFT">
+					<Size x="80"/>
+					<Anchors>
+						<Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.EstHonor"/>
 					</Anchors>
 				</FontString>
 				<FontString parentKey="Standing" inherits="GameFontHighlightSmall" justifyH="LEFT">

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -26,11 +26,16 @@ L["Report specific player standings"] = true
 L["player_name"] = true
 L["Player %s not found in table"] = true
 
+L["Pool Booster Count"] = true
+L["Number of characters to add to Pool"] = true
+
 L["Report"] = true
 L["Report for player"] = true
 L["Report Target"] = true
 L["Report Me"] = true
 L["Pool Size"] = true
+L["Natural Pool Size"] = true
+L["Boosted Pool Size"] = true
 L["Standing"] = true
 L["Bracket"] = true
 L["Current RP"] = true
@@ -62,6 +67,8 @@ L["Limit"] = true
 L['You have 0 honor or not enough HKs, min = 15'] = true
 L["Hide Minimap Button"] = true
 L["Use \'/hs show\' to bring HonorSpy window, if hidden. Will Reload UI on change."] = true
+L["Show Estimated Honor"] = true
+L["Shows the Estimated Honor column in the table. This data will only be populated by other people with HonorSpy."] = true
 L["Estimated Honor"] = true
 L["Sync over GUILD instead of separate 'HonorSpySync' channel"] = true
 L["You won't join 'HonorSpySync' channel anymore and will only sync data with your guildmates. Relog after changing this."] = true

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -6,6 +6,7 @@ L["HonorSpy Standings"] = true
 L["Name"] = true
 L["Honor"] = true
 L["ThisWeekHonor"] = true
+L["EstHonor"] = true
 L["LstWkHonor"] = true
 L["Standing"] = true
 L["RP"] = true

--- a/export.lua
+++ b/export.lua
@@ -24,7 +24,7 @@ function HonorSpy:ExportCSV()
 		
 		local editBox = CreateFrame("EditBox", "ARLCopyEdit", frame)
 		editBox:SetMultiLine(true)
-		editBox:SetMaxLetters(999999)
+		editBox:SetMaxLetters(99999)
 		editBox:EnableMouse(true)
 		editBox:SetAutoFocus(false)
 		editBox:SetFontObject(ChatFontNormal)

--- a/export.lua
+++ b/export.lua
@@ -24,7 +24,7 @@ function HonorSpy:ExportCSV()
 		
 		local editBox = CreateFrame("EditBox", "ARLCopyEdit", frame)
 		editBox:SetMultiLine(true)
-		editBox:SetMaxLetters(99999)
+		editBox:SetMaxLetters(999999)
 		editBox:EnableMouse(true)
 		editBox:SetAutoFocus(false)
 		editBox:SetFontObject(ChatFontNormal)

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -97,6 +97,9 @@ function HonorSpy:INSPECT_HONOR_UPDATE()
 	player.thisWeekHonor = thisWeekHonor;
 	player.lastWeekHonor = lastWeekHonor;
 	player.standing = standing;
+	if ( inspectedPlayerName == playerName ) then
+		player.estHonor = HonorSpy.db.char.estimated_honor
+	end
 
 	player.rankProgress = GetInspectPVPRankProgress();
 	ClearInspectPlayer();
@@ -235,12 +238,13 @@ LibStub("AceConfig-3.0"):RegisterOptionsTable("HonorSpy", options, {"honorspy", 
 function HonorSpy:BuildStandingsTable(sort_by)
 	local t = { }
 	for playerName, player in pairs(HonorSpy.db.factionrealm.currentStandings) do
-		table.insert(t, {playerName, player.class, player.thisWeekHonor or 0, player.lastWeekHonor or 0, player.standing or 0, player.RP or 0, player.rank or 0, player.last_checked or 0})
+		table.insert(t, {playerName, player.class, player.thisWeekHonor or 0, player.estHonor or 0, player.lastWeekHonor or 0, player.standing or 0, player.RP or 0, player.rank or 0, player.last_checked or 0})
 	end
 	
 	local sort_column = 3; -- ThisWeekHonor
-	if (sort_by == L["Standing"]) then sort_column = 4; end
-	if (sort_by == L["Rank"]) then sort_column = 6; end
+	if (sort_by == L["EstHonor"]) then sort_column = 4; end
+	if (sort_by == L["Standing"]) then sort_column = 5; end
+	if (sort_by == L["Rank"]) then sort_column = 7; end
 	local sort_func = function(a,b)
 		return a[sort_column] > b[sort_column]
 	end

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -17,9 +17,11 @@ function HonorSpy:OnInitialize()
 			currentStandings = {},
 			last_reset = 0,
 			minimapButton = {hide = false},
+			estHonorCol = {show = false},
 			actualCommPrefix = "",
 			fakePlayers = {},
-			goodPlayers = {}
+			goodPlayers = {},
+			poolBoost = 0
 		},
 		char = {
 			today_kills = {},
@@ -238,7 +240,7 @@ LibStub("AceConfig-3.0"):RegisterOptionsTable("HonorSpy", options, {"honorspy", 
 function HonorSpy:BuildStandingsTable(sort_by)
 	local t = { }
 	for playerName, player in pairs(HonorSpy.db.factionrealm.currentStandings) do
-		table.insert(t, {playerName, player.class, player.thisWeekHonor or 0, player.estHonor or 0, player.lastWeekHonor or 0, player.standing or 0, player.RP or 0, player.rank or 0, player.last_checked or 0})
+		table.insert(t, {playerName, player.class, player.thisWeekHonor or 0, player.estHonor or "", player.lastWeekHonor or 0, player.standing or 0, player.RP or 0, player.rank or 0, player.last_checked or 0})
 	end
 	
 	local sort_column = 3; -- ThisWeekHonor
@@ -246,6 +248,7 @@ function HonorSpy:BuildStandingsTable(sort_by)
 	if (sort_by == L["Standing"]) then sort_column = 5; end
 	if (sort_by == L["Rank"]) then sort_column = 7; end
 	local sort_func = function(a,b)
+		if sort_column == 4 then return math.max(a[3],tonumber(a[4]) or 0) > math.max(b[3],tonumber(b[4]) or 0) end
 		return a[sort_column] > b[sort_column]
 	end
 	table.sort(t, sort_func)
@@ -258,11 +261,13 @@ function HonorSpy:GetBrackets(pool_size)
 			  -- 1   2       3      4	  5		 6		7	   8		9	 10		11		12		13	14
 	local brk =  {1, 0.845, 0.697, 0.566, 0.436, 0.327, 0.228, 0.159, 0.100, 0.060, 0.035, 0.020, 0.008, 0.003} -- brackets percentage
 	
+	pool_size = pool_size + HonorSpy.db.factionrealm.poolBoost
+
 	if (not pool_size) then
 		return brk
 	end
 	for i = 1,14 do
-		brk[i] = math.floor(brk[i]*pool_size+.5)
+		brk[i] = math.min(math.floor(brk[i]*pool_size+.5), #HonorSpy:BuildStandingsTable())
 	end
 	return brk
 end
@@ -275,37 +280,55 @@ function HonorSpy:Estimate(playerOfInterest)
 
 	
 	local standing = -1;
-	local t = HonorSpy:BuildStandingsTable()
-	local avg_lastchecked = 0;
+	local t = HonorSpy:BuildStandingsTable(L["EstHonor"])
 	local pool_size = #t;
+	local curHonor = 0;
 
 	for i = 1, pool_size do
 		if (playerOfInterest == t[i][1]) then
 			standing = i
+			curHonor = math.max(t[i][3], tonumber(t[i][4]) or 0)
 		end
 	end
+	
 	if (standing == -1) then
 		return
 	end;
+
+	local pool_size = pool_size
 
 	local RP  = {0, 400} -- RP for each bracket
 	local Ranks = {0, 2000} -- RP for each rank
 
 	local bracket = 1;
+	local top_bracket = 14;
 	local inside_br_progress = 0;
+	
 	local brk = self:GetBrackets(pool_size)
-
+	
 	for i = 2,14 do
+		if (brk[i] == 0) then
+			top_bracket = i
+		end
 		if (standing > brk[i]) then
-			inside_br_progress = (brk[i-1] - standing)/(brk[i-1] - brk[i])
 			break
-		end;
+		end
 		bracket = i;
 	end
-	if (bracket == 14 and standing == 1) then inside_br_progress = 1 end;
+
+	local btm_break_point_honor = math.max(t[brk[bracket]][3], tonumber(t[brk[bracket]][4]) or 0)
+	local top_break_point_honor = 0
+	
+	if bracket ~= top_bracket then
+		top_break_point_honor = math.max(t[brk[bracket + 1]][3], tonumber(t[brk[bracket + 1]][4]) or 0)
+	else
+		top_break_point_honor = math.max(t[1][3], tonumber(t[1][4]) or 0)
+	end
+
+	inside_br_progress = (curHonor - btm_break_point_honor)/(top_break_point_honor - btm_break_point_honor)
 	for i = 3,14 do
-		RP[i] = (i-2) * 1000;
-		Ranks[i] = (i-2) * 5000;
+		RP[i] = (i-2) * 1000
+		Ranks[i] = (i-2) * 5000
 	end
 	local award = RP[bracket] + 1000 * inside_br_progress;
 	local RP = HonorSpy.db.factionrealm.currentStandings[playerOfInterest].RP;

--- a/settings.lua
+++ b/settings.lua
@@ -26,21 +26,51 @@ options.args["sep1"] = {
 	name = "\n"
 }
 
-options.args["sep1"] = {
+options.args["estHonorCol"] = {
 	order = 3,
+	type = "toggle",
+	name = L["Show Estimated Honor"],
+	desc = L["Shows the Estimated Honor column in the table. This data will only be populated by other people with HonorSpy."],
+	get = function() return HonorSpy.db.factionrealm.estHonorCol.show end,
+	set = function(info, v) HonorSpy.db.factionrealm.estHonorCol.show = v; HonorSpyGUI:PrepareGUI() end,
+}
+
+options.args["estHonorColDesc"] = {
+	order = 4,
+	type = "description",
+	name = L["Shows the Estimated Honor column in the table. This data will only be populated by other people with HonorSpy."] .. '\n\n'
+}
+
+options.args["sep1"] = {
+	order = 5,
+	type = "description",
+	name = "\n"
+}
+
+options.args["poolBoost"] = {
+	order = 6,
+	type = "input",
+	name = L["Pool Booster Count"],
+	desc = L["Number of characters to add to Pool"],
+	get = function() return HonorSpy.db.factionrealm.poolBoost end,
+	set = function(info, v) HonorSpy.db.factionrealm.poolBoost = v; end
+}
+
+options.args["sep1"] = {
+	order = 7,
 	type = "description",
 	name = "\n"
 }
 
 options.args["export"] = {
-	order = 4,
+	order = 8,
 	type = "execute",
 	name = L["Export to CSV"],
 	desc = L["Show window with current data in CSV format"],
 	func = function() HonorSpy:ExportCSV() end,
 }
 options.args["purge_data"] = {
-	order = 5,
+	order = 9,
 	type = "execute",
 	name = L["_ purge all data"],
 	desc = L["Delete all collected data"],


### PR DESCRIPTION
This is something I wanted and though it'd be pretty easy to add. Turns out it was. This just add a new property to the player table for estimated honor if it knows it (basically, if you're reporting yourself). It gives it to the broadcast as well so people in your raid/guild/proximity will also receive it.

Also modified the GUI to show this as well.