### PR TITLE
Fixed player testing notification sounds and flood of messages

### DIFF
--- a/honorspy.toc
+++ b/honorspy.toc
@@ -8,7 +8,7 @@
 
 ## Author: kakysha
 ## OptionalDeps: Ace3
-## Version: 1.7.15
+## Version: 1.7.16
 
 ## X-Category: Battlegrounds/PvP
 ## SavedVariables: HonorSpyDB

--- a/honorspy.toc
+++ b/honorspy.toc
@@ -8,7 +8,7 @@
 
 ## Author: kakysha
 ## OptionalDeps: Ace3
-## Version: 1.7.14
+## Version: 1.7.15
 
 ## X-Category: Battlegrounds/PvP
 ## SavedVariables: HonorSpyDB


### PR DESCRIPTION
Throttled database population, fixed player testing bug that was ultimately causing 'Unknown friend response from server.' messages. 
Fixed notification sounds while fake player testing is occurring. Sound may be muted for friends/guild members coming online during mass population but this should be rare.