### PR TITLE
Track everyone who has earned at least 15 HKs today + add second estimated honor column to show (this week + todays estimate)

### DIFF
--- a/GUI.lua
+++ b/GUI.lua
@@ -110,12 +110,14 @@ function GUI:UpdateTableView()
 			brk_delim_inserted = true
 			button.Name:SetText(colorize(format(L["Bracket"] .. " %d", brackets[itemIndex]), "GREY"))
 			button.Honor:SetText();
+            button.EstHonor:SetText();
+            button.EstWeekHonor:SetText();
 			if HonorSpy.db.factionrealm.estHonorCol.show then
-				button.EstHonor:SetText();
 				button.EstHonor:SetWidth(80);
+                button.EstWeekHonor:SetWidth(80);
 			else
-				button.EstHonor:SetText();
 				button.EstHonor:SetWidth(0);
+                button.EstWeekHonor:SetWidth(0);
 			end
 			button.LstWkHonor:SetText();
 			button.Standing:SetText();
@@ -140,13 +142,18 @@ function GUI:UpdateTableView()
 			end
 			button:SetID(itemIndex);
 			button.Name:SetText(colorize(itemIndex .. ')  ', "GREY") .. colorize(name, class));
-			button.Honor:SetText(colorize(thisWeekHonor, class));
+			if tonumber(thisWeekHonor) == 1 then thisWeekHonor = 0 end
+            button.Honor:SetText(colorize(thisWeekHonor, class));
 			if HonorSpy.db.factionrealm.estHonorCol.show then 
 				button.EstHonor:SetText(colorize(estHonor, class)); 
 				button.EstHonor:SetWidth(80);
+                button.EstWeekHonor:SetText(colorize((tonumber(estHonor) or 0) + (tonumber(thisWeekHonor) or 0), class));
+                button.EstWeekHonor:SetWidth(80);
 			else 
 				button.EstHonor:SetText();
 				button.EstHonor:SetWidth(0);
+                button.EstWeekHonor:SetText();
+                button.EstWeekHonor:SetWidth(0);
 			end
 			button.LstWkHonor:SetText(colorize(lastWeekHonor, class));
 			button.Standing:SetText(colorize(standing, class));
@@ -181,7 +188,7 @@ function GUI:PrepareGUI()
 	_G["HonorSpyGUI_MainFrame"] = mainFrame
 	tinsert(UISpecialFrames, "HonorSpyGUI_MainFrame")	-- allow ESC close
 	mainFrame:SetTitle(L["HonorSpy Standings"])
-	if HonorSpy.db.factionrealm.estHonorCol.show then mainFrame:SetWidth(680) else mainFrame:SetWidth(600) end
+	if HonorSpy.db.factionrealm.estHonorCol.show then mainFrame:SetWidth(760) else mainFrame:SetWidth(600) end
 	mainFrame:SetLayout("List")
 	mainFrame:EnableResize(false)
 
@@ -225,6 +232,8 @@ function GUI:PrepareGUI()
 	tableHeader:AddChild(btn)
 
 	if HonorSpy.db.factionrealm.estHonorCol.show then
+        btn:SetText(colorize(L["KnownHonor"], "ORANGE"))
+
 		btn = AceGUI:Create("InteractiveLabel")
 		btn:SetCallback("OnClick", function()
 			GUI:Show(false, L["EstHonor"])
@@ -233,6 +242,15 @@ function GUI:PrepareGUI()
 		btn:SetWidth(80)
 		btn:SetText(colorize(L["EstHonor"], "ORANGE"))
 		tableHeader:AddChild(btn)
+        
+        btn = AceGUI:Create("InteractiveLabel")
+        btn:SetCallback("OnClick", function()
+            GUI:Show(false, L["ThisWeekHonor"])
+        end)
+        btn.highlight:SetColorTexture(0.3, 0.3, 0.3, 0.5)
+        btn:SetWidth(80)
+        btn:SetText(colorize(L["ThisWeekHonor"], "ORANGE"))
+        tableHeader:AddChild(btn)
 	end
 
 	btn = AceGUI:Create("InteractiveLabel")

--- a/HybridScrollFrame.xml
+++ b/HybridScrollFrame.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://www.blizzard.com/wow/ui/..\FrameXML\UI.xsd">
 
 	<Frame name="HybridScrollListItemTemplate" virtual="true">
-		<Size y="12" x="640"/>
+		<Size y="12" x="720"/>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<Texture parentKey="Background" setAllPoints="true">
@@ -26,10 +26,16 @@
 						<Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.Honor"/>
 					</Anchors>
 				</FontString>
+                <FontString parentKey="EstWeekHonor" inherits="GameFontHighlightSmall" justifyH="LEFT">
+                    <Size x="80"/>
+                    <Anchors>
+                        <Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.EstHonor"/>
+                    </Anchors>
+                </FontString>
 				<FontString parentKey="LstWkHonor" inherits="GameFontHighlightSmall" justifyH="LEFT">
 					<Size x="80"/>
 					<Anchors>
-						<Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.EstHonor"/>
+						<Anchor point="TOPLEFT" relativePoint="TOPRIGHT" relativeKey="$parent.EstWeekHonor"/>
 					</Anchors>
 				</FontString>
 				<FontString parentKey="Standing" inherits="GameFontHighlightSmall" justifyH="LEFT">

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -5,8 +5,9 @@ if L then
 L["HonorSpy Standings"] = true
 L["Name"] = true
 L["Honor"] = true
-L["ThisWeekHonor"] = true
-L["EstHonor"] = true
+L["KnownHonor"] = true
+L["ThisWeekHonor"] = "EstWeekHonor"
+L["EstHonor"] = "EstTodayHonor"
 L["LstWkHonor"] = true
 L["Standing"] = true
 L["RP"] = true

--- a/Localizations/esES.lua
+++ b/Localizations/esES.lua
@@ -5,6 +5,7 @@ if L then
 L["HonorSpy Standings"] = "Clasificación de HonorSpy"
 L["Name"] = "Nombre"
 L["Honor"] = "Honor"
+L["KnownHonor"] = true
 L["ThisWeekHonor"] = "Esta semana"
 L["EstHonor"] = "HonorEst."
 L["LstWkHonor"] = "Previa semana"

--- a/Localizations/esMX.lua
+++ b/Localizations/esMX.lua
@@ -5,6 +5,7 @@ if L then
 L["HonorSpy Standings"] = "Clasificación de HonorSpy"
 L["Name"] = "Nombre"
 L["Honor"] = "Honor"
+L["KnownHonor"] = true
 L["ThisWeekHonor"] = "Esta semana"
 L["EstHonor"] = "HonorEst."
 L["LstWkHonor"] = "Previa semana"

--- a/Localizations/koKR.lua
+++ b/Localizations/koKR.lua
@@ -5,6 +5,7 @@ if L then
 L["HonorSpy Standings"] = "HonorSpy 순위"
 L["Name"] = "이름"
 L["Honor"] = "명예"
+L["KnownHonor"] = true
 L["ThisWeekHonor"] = "이번 주 명예"
 L["EstHonor"] = true
 L["LstWkHonor"] = "지난 주 명예"

--- a/Localizations/ruRU.lua
+++ b/Localizations/ruRU.lua
@@ -5,6 +5,7 @@ if L then
 L["HonorSpy Standings"] = "Таблица HonorSpy"
 L["Name"] = "Игрок"
 L["Honor"] = "Честь"
+L["KnownHonor"] = true
 L["ThisWeekHonor"] = "ЧестьНаЭтойНеделе"
 L["EstHonor"] = "ОжидЧесть"
 L["LstWkHonor"] = "ЧестьНаПрНед"

--- a/Localizations/zhCN.lua
+++ b/Localizations/zhCN.lua
@@ -5,6 +5,7 @@ if L then
 L["HonorSpy Standings"] = "荣誉监视榜"
 L["Name"] = "名字"
 L["Honor"] = "荣誉"
+L["KnownHonor"] = true
 L["ThisWeekHonor"] = "本周荣誉"
 L["EstHonor"] = true
 L["LstWkHonor"] = "上周荣誉"

--- a/Localizations/zhTW.lua
+++ b/Localizations/zhTW.lua
@@ -5,6 +5,7 @@ if L then
 L["HonorSpy Standings"] = "榮譽監視榜"
 L["Name"] = "名字"
 L["Honor"] = "榮譽"
+L["KnownHonor"] = true
 L["EstHonor"] = true
 L["ThisWeekHonor"] = "本周榮譽"
 L["LstWkHonor"] = "上周榮譽"

--- a/honorspy.toc
+++ b/honorspy.toc
@@ -8,7 +8,7 @@
 
 ## Author: kakysha
 ## OptionalDeps: Ace3
-## Version: 1.7.18
+## Version: 1.7.20
 
 ## X-Category: Battlegrounds/PvP
 ## SavedVariables: HonorSpyDB


### PR DESCRIPTION
Example output:
![image](https://user-images.githubusercontent.com/49792789/152217798-ce60547f-757f-4636-99c3-3e6262108e0b.png)

Those players at the bottom of the list didn't do any pvp yesterday, but have earned at least 15 HKs today. If they were to also run this updated HS, they would transmit their estimated honor too.