### PR TITLE
TOC Update for 1.14.2 + use other functions to avoid "inspecting onesself"

### DIFF
--- a/honorspy.lua
+++ b/honorspy.lua
@@ -79,7 +79,7 @@ local function processInspect(player, name, todayHK, thisweekHK, thisWeekHonor, 
     player.thisWeekHonor = thisWeekHonor;
 	player.lastWeekHonor = lastWeekHonor;
 	player.standing = standing;
-	if ( inspectedPlayerName == playerName ) then
+	if ( name == playerName ) then
 		player.estHonor = HonorSpy.db.char.estimated_honor
 	end
 
@@ -95,7 +95,7 @@ local function processInspect(player, name, todayHK, thisweekHK, thisWeekHonor, 
 			player.RP = math.ceil(player.rankProgress * 3000 + 2000)
 		end
 		store_player(name, player)
-		broadcast(self:Serialize(name, player))
+		broadcast(HonorSpy:Serialize(name, player))
 	else
 		HonorSpy.db.factionrealm.currentStandings[name] = nil
 	end
@@ -106,7 +106,7 @@ local function StartInspecting(unitID)
     
     if unitID == "player" then
         -- Instead of waiting for an inspect of self, we can use GetPVPSessionStats and GetPVPThisWeekStats
-        local player = HonorSpy.db.factionrealm.currentStandings[name]
+        local player = HonorSpy.db.factionrealm.currentStandings[name] or {last_checked = 0, unitID = "player", rank = select(2, GetPVPRankInfo(UnitPVPRank("player"))), class = select(2, UnitClass("player")),}
 	    if (player == nil) then return end
 	    if (player.class == nil) then player.class = "nil" end
 

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -691,7 +691,6 @@ function HonorSpy:Purge()
 	inspectedPlayers = {};
 	HonorSpy.db.factionrealm.currentStandings={};
 	HonorSpy.db.factionrealm.fakePlayers={};
-	HonorSpy.db.char.original_honor = 0;
 	HonorSpyGUI:Reset();
 	HonorSpy:Print(L["All data was purged"]);
 end
@@ -749,19 +748,6 @@ function HonorSpy:CheckNeedReset(skipUpdate)
 
 	-- reset weekly standings
 	local must_reset_on = getResetTime()
-	
-    -- Backward compatibility
-    if (HonorSpy.db.char.last_reset == 0) then
-        HonorSpy.db.char.last_reset = HonorSpy.db.factionrealm.last_reset or 0
-    end
-    
-    -- Reset just the characters totals
-    if (HonorSpy.db.char.last_reset ~= must_reset_on) then
-        HonorSpy.db.char.last_reset = must_reset_on
-		HonorSpy.db.char.original_honor = 0
-		HonorSpy.db.char.estimated_honor = 0
-		HonorSpy.db.char.today_kills = {}
-	end
     
     -- Reset the rest of the database only if it hasn't already been done on an alt this week
     if (HonorSpy.db.factionrealm.last_reset ~= must_reset_on) then
@@ -773,12 +759,6 @@ function HonorSpy:CheckNeedReset(skipUpdate)
 	local _, thisWeekHonor = GetPVPThisWeekStats()
     if (HonorSpy.db.char.original_honor ~= thisWeekHonor) then
         HonorSpy.db.char.original_honor = thisWeekHonor
-        
-        -- backward compatibility
-        if HonorSpy.db.char.estimated_honor > thisWeekHonor then
-            return
-        end
-        
         HonorSpy.db.char.estimated_honor = thisWeekHonor
 		HonorSpy.db.char.today_kills = {}
 	end

--- a/honorspy.toc
+++ b/honorspy.toc
@@ -1,4 +1,4 @@
-## Interface: 11401
+## Interface: 11402
 ## Title: HonorSpy
 
 ## Notes: Records PvP standings of all players
@@ -8,7 +8,7 @@
 
 ## Author: kakysha
 ## OptionalDeps: Ace3
-## Version: 1.7.20
+## Version: 1.8.1
 
 ## X-Category: Battlegrounds/PvP
 ## SavedVariables: HonorSpyDB


### PR DESCRIPTION
1. I've bumped the TOC for Classic v1.14.2 which released today
2. I have made collecting the players own data a bit more efficient, and not dependent on the Inspection system by:
- Moving some of the processing logic into a new local "processInspect" so I don't duplicate the same code, and
- When intending to inspect the players own honor, instead of making calls to NotifyInspect and RequestInspectHonorData, the player will just get the existing data from other functions like GetPVPSessionData and GetPVPThisWeekData, etc, and process them immediately. No need to wait for an inspect, and the player will no longer need to wait 30 seconds between checks just to update their own data.
- The intention behind this change is to assist in capturing accurate numbers of "padding characters" on the ladder, as currently they often miss their broadcasts due to the 30 second delay. Often they logout before the 30 seconds is up and never reinspect themselves after getting 15HKs.