### PR TITLE
Minor bugfix and an addon chat throttle

### DIFF
--- a/honorspy.lua
+++ b/honorspy.lua
@@ -231,11 +231,11 @@ end
 
 -- this is called after eventg	ww
 function CHAT_MSG_COMBAT_HONOR_GAIN_FILTER(_s, e, msg, ...)
-	HonorSpy:CheckNeedReset()
 	local victim, est_honor, awarded_honor = parseHonorMessage(msg)
 	if (not victim) then
 		return
 	end
+    C_Timer.After(1, HonorSpy.CheckNeedReset) -- At this point, GetPVPSessionStats() hasn't always yet updated with the new HK
 	return false, format("%s kills: %d, honor: |cff00FF96%d", msg, HonorSpy.db.char.today_kills[victim] or 0, est_honor), ...
 end
 

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -125,7 +125,7 @@ local function StartInspecting(unitID)
             (lastPlayerLastWeekHonor ~= lastWeekHonor) or
             (lastPlayerStanding ~= standing) or
             (lastPlayerRankProgress ~= rankProgress) or
-            (lastPlayerChecked and ((GetServerTime() - lastPlayerChecked) < 60)) then
+            (lastPlayerChecked and ((GetServerTime() - lastPlayerChecked) > 60)) then
                 processInspect(player, name, todayHK, thisweekHK, thisWeekHonor, lastWeekHonor, standing, rankProgress)
                 lastPlayerTodayHK, lastPlayerEstHonor, lastPlayerThisweekHK, lastPlayerThisWeekHonor, lastPlayerLastWeekHonor, lastPlayerStanding, lastPlayerRankProgress, lastPlayerChecked = todayHK, player.estHonor, thisweekHK, thisWeekHonor, lastWeekHonor, standing, rankProgress, GetServerTime()
         end

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -101,6 +101,9 @@ local function processInspect(player, name, todayHK, thisweekHK, thisWeekHonor, 
 	end
 end
 
+-- store the last checked details about the player, so we can only re-broadcast if something actually changed, or enough time has passed
+local lastPlayerTodayHK, lastPlayerEstHonor, lastPlayerThisweekHK, lastPlayerThisWeekHonor, lastPlayerLastWeekHonor, lastPlayerStanding, lastPlayerRankProgress, lastPlayerChecked
+
 local function StartInspecting(unitID)
 	local name, realm = UnitName(unitID);
     
@@ -114,8 +117,18 @@ local function StartInspecting(unitID)
         local thisweekHK, thisWeekHonor = GetPVPThisWeekStats()
         local _, _, lastWeekHonor, standing = GetPVPLastWeekStats()
         local rankProgress = GetPVPRankProgress()
-	
-        processInspect(player, name, todayHK, thisweekHK, thisWeekHonor, lastWeekHonor, standing, rankProgress)
+
+        if (lastPlayerTodayHK ~= todayHK) or
+            (lastPlayerEstHonor ~= player.estHonor) or
+            (lastPlayerThisweekHK ~= thisweekHK) or
+            (lastPlayerThisWeekHonor ~= thisWeekHonor) or
+            (lastPlayerLastWeekHonor ~= lastWeekHonor) or
+            (lastPlayerStanding ~= standing) or
+            (lastPlayerRankProgress ~= rankProgress) or
+            (lastPlayerChecked and ((GetServerTime() - lastPlayerChecked) < 60)) then
+                processInspect(player, name, todayHK, thisweekHK, thisWeekHonor, lastWeekHonor, standing, rankProgress)
+                lastPlayerTodayHK, lastPlayerEstHonor, lastPlayerThisweekHK, lastPlayerThisWeekHonor, lastPlayerLastWeekHonor, lastPlayerStanding, lastPlayerRankProgress, lastPlayerChecked = todayHK, player.estHonor, thisweekHK, thisWeekHonor, lastWeekHonor, standing, rankProgress, GetServerTime()
+        end
     else
         if (paused or (not C_PlayerInfo.UnitIsSameServer(PlayerLocation:CreateFromUnit(unitID)))) then
             return

--- a/honorspy.toc
+++ b/honorspy.toc
@@ -8,7 +8,7 @@
 
 ## Author: kakysha
 ## OptionalDeps: Ace3
-## Version: 1.8.1
+## Version: 1.8.2
 
 ## X-Category: Battlegrounds/PvP
 ## SavedVariables: HonorSpyDB


### PR DESCRIPTION
When I removed the addons reliance on Inspect to check the player's own data, it bypassed the spamfilters. This fix should make it only rebroadcast if the player's own data has actually changed, or its been more than a minute since the last check. I was watching the addon comms, and it would often broadcast data about the player twice, this should be fixed now.

Also fixed a bug where the player would get their 15th HK but never broadcast anything. This was because when it checked, it still thought it only had 14HKs and discarded the data.