### PR TITLE
Add hourly DB share to help with low populated realms accuracy

### DIFF
--- a/honorspy.lua
+++ b/honorspy.lua
@@ -65,6 +65,8 @@ function HonorSpy:OnInitialize()
 	HonorSpyGUI:PrepareGUI()
 	PrintWelcomeMsg();
 	DBHealthCheck()
+
+	C_Timer.NewTicker(60*60, function() HonorSpy:broadcastPlayers(true) end)
 end
 
 local inspectedPlayers = {}; -- stores last_checked time of all players met


### PR DESCRIPTION
The death broadcast isn't enough on low population ERA clusters.
This simple hourly broadcast helps to improves accuracy for players.

As the first broadcast only happens after 1h after being online, it doesn't spam much when switching chars and doesn't result in throttling as far as I tested it.