### PR TITLE
CommPrefix bump to 5 + others

### DIFF
--- a/honorspy.lua
+++ b/honorspy.lua
@@ -3,7 +3,7 @@ HonorSpy = LibStub("AceAddon-3.0"):NewAddon("HonorSpy", "AceConsole-3.0", "AceHo
 local L = LibStub("AceLocale-3.0"):GetLocale("HonorSpy", true)
 
 local addonName = GetAddOnMetadata("HonorSpy", "Title");
-local commPrefix = addonName .. "4";
+local commPrefix = addonName .. "5";
 
 local paused = false; -- pause all inspections when user opens inspect frame
 local playerName = UnitName("player");

--- a/honorspy.toc
+++ b/honorspy.toc
@@ -8,7 +8,7 @@
 
 ## Author: kakysha
 ## OptionalDeps: Ace3
-## Version: 1.8.5
+## Version: 1.8.6
 
 ## X-Category: Battlegrounds/PvP
 ## SavedVariables: HonorSpyDB


### PR DESCRIPTION
**Please don't release this midweek.** If you can't accept the PR and tag a release before tomorrow (Thursday) please wait until Monday. I don't want to have a mess of half-updated players over the weekend to deal with.

In world pvp, the chatlog was showing messages like "Enemyplayer died, honorable kill 5" even if Enemyplayer was actually on another server. This means the kill counter was being saved under Enemyplayer-Arugal when it should be saved under Enemyplayer-Yojamba. I can get their realm from the UNIT_DIED subevent of the COMBAT_LOG event, and store it in a cache. This isn't 100% if there are two players with the same name from different realms both doing pvp at the same time. But that should be niche enough to not matter.

Also made a bunch of functions local that were leaking into the global namespace. If testing becomes a problem later on I might shove them into the HonorSpy: namespace instead.