### PR TITLE
Use full name-server string for stored player, even from same servers

### DIFF
--- a/GUI.lua
+++ b/GUI.lua
@@ -21,7 +21,7 @@ local colors = {
 	["NORMAL"] = "f2ca45"
 }
 
-local playerName = UnitName("player")
+local playerName = HonorSpyUtils:getFullUnitName("player")
 
 function GUI:Show(skipUpdate, sort_column)
 	if (not skipUpdate) then
@@ -146,7 +146,9 @@ function GUI:UpdateTableView()
 				last_seen_human = ""..last_seen..L["s"]
 			end
 			button:SetID(itemIndex);
-            button.Name:SetText(colorize(itemIndex .. ')  ', "GREY") .. colorize(name, class));
+            button.Name:SetText(
+				colorize(itemIndex .. ')  ', "GREY") .. colorize(HonorSpyUtils:getDisplayName(name), class)
+			);
             button.Name:SetNonSpaceWrap(false)
             button.Name:SetWordWrap(false)
 			if tonumber(thisWeekHonor) == 1 then thisWeekHonor = 0 end
@@ -238,7 +240,7 @@ function GUI:PrepareGUI()
 	reportBtn:SetRelativeWidth(0.19)
 	reportBtn.text:SetFontObject("SystemFont_NamePlate")
 	reportBtn:SetCallback("OnClick", function()
-		HonorSpy:Report(UnitIsPlayer("target") and GetUnitName("target", true) or nil)
+		HonorSpy:Report(UnitIsPlayer("target") and HonorSpyUtils:getFullUnitName("target", true) or nil)
 	end)
 	playerStandingsGrp:AddChild(reportBtn)
 

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -440,19 +440,17 @@ function HonorSpy:Estimate(playerOfInterest)
 	if (not playerOfInterest) then
 		playerOfInterest = playerName
 	end
-	playerOfInterest = string.utf8lower(playerOfInterest)
-	
+
 	local standing = -1;
 	local t = HonorSpy:BuildStandingsTable(L["ThisWeekHonor"])
 	local pool_size = #t;
 	local curHonor = 0;
 	local rp_factor = 1000;
 	local decay_factor = 0.8;
-	
+
 	for i = 1, pool_size do
-		if (playerOfInterest == string.utf8lower(t[i][1])) then
+		if (playerOfInterest == t[i][1]) then
 			standing = i
-            playerOfInterest = t[i][1]
 			curHonor = math.max(t[i][3], tonumber(t[i][4]) or 0)
 		end
 	end
@@ -527,8 +525,7 @@ function HonorSpy:Report(playerOfInterest, skipUpdate)
 	if (playerOfInterest == playerName) then
 		HonorSpy:UpdatePlayerData() -- will update for next time, this report gonna be for old data
 	end
-	playerOfInterest = string.utf8upper(string.utf8sub(playerOfInterest, 1, 1))..string.utf8lower(string.utf8sub(playerOfInterest, 2))
-	
+
 	local pool_size, standing, bracket, RP, EstRP, Rank, Progress, EstRank, EstProgress = HonorSpy:Estimate(playerOfInterest)
 	if (not standing) then
 		self:Print(format(L["Player %s not found in table"], playerOfInterest));

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -60,7 +60,16 @@ local function playerIsValid(player)
 end
 
 local function store_player(playerName, player)
-	if (player == nil or playerName == nil or playerName:gsub("%-","",1):find("[%d%p%s%c%z]") or isFakePlayer(playerName) or not playerIsValid(player)) then return end
+	if (
+		player == nil or
+		playerName == nil or
+		not playerName:find("-") or
+		playerName:gsub("%-", "", 1):find("[%d%p%s%c%z]") or
+		isFakePlayer(playerName) or
+		not playerIsValid(player)
+	) then
+		return
+	end
 	
 	if(addingPlayer) then
 		C_Timer.After(0.1,function() store_player(playerName, player); end)

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -650,6 +650,7 @@ local function FAKE_PLAYERS_FILTER(_s, e, msg, ...)
 	
 	friend = msg:match(ERR_FRIEND_ONLINE_PATTERN)
 	if (friend) then
+		local friendFullName = HonorSpyUtils:getCompleteName(friend)
 		local f = C_FriendList.GetFriendInfo(friend)
 		if(nameToTest and not f) then
 			if (nameToTest == friend) then
@@ -657,8 +658,8 @@ local function FAKE_PLAYERS_FILTER(_s, e, msg, ...)
 			end
 		else
 			if (f and (friend == nameToTest or f.notes == "HonorSpy testing")) then
-				HonorSpy.db.factionrealm.goodPlayers[friend] = true
-				HonorSpy.db.factionrealm.fakePlayers[friend] = nil
+				HonorSpy.db.factionrealm.goodPlayers[friendFullName] = true
+				HonorSpy.db.factionrealm.fakePlayers[friendFullName] = nil
 				return true;
 			end
 		end

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -562,10 +562,9 @@ function table.copy(t)
 end
 
 function HonorSpy:OnCommReceive(prefix, message, distribution, sender)
-    local connectedRealm = false
-	local senderName, sendersRealm = HonorSpyUtils:getRealmFromFullUnitName(sender)
+	local sendersRealm = HonorSpyUtils:getRealmFromFullUnitName(sender)
 
-	if (distribution ~= "GUILD" and HonorSpy.db.factionrealm.connectedRealms[sendersRealm] == nil) then
+	if (distribution ~= "GUILD" and sendersRealm and HonorSpy.db.factionrealm.connectedRealms[sendersRealm] == nil) then
 		return -- discard any message from players not from the same realm or connected realms (connected on ERA only)
 	end
     

--- a/honorspy.lua
+++ b/honorspy.lua
@@ -377,7 +377,7 @@ LibStub("AceConfig-3.0"):RegisterOptionsTable("HonorSpy", options, {"honorspy", 
 function HonorSpy:BuildStandingsTable(sort_by)
 	local t = { }
 	for playerName, player in pairs(HonorSpy.db.factionrealm.currentStandings) do
-		table.insert(t, {playerName, player.class, tonumber(player.thisWeekHonor) or 0, tonumber(player.estHonor) or 0, tonumber(player.lastWeekHonor) or 0, tonumber(player.standing) or 0, player.RP or 0, player.rank or 0, player.last_checked or 0})
+		table.insert(t, {playerName, player.class, tonumber(player.thisWeekHonor) or 0, tonumber(player.estHonor), tonumber(player.lastWeekHonor) or 0, tonumber(player.standing) or 0, player.RP or 0, player.rank or 0, player.last_checked or 0})
 	end
 	
 	local sort_column = 3; -- KnownHonor
@@ -387,26 +387,30 @@ function HonorSpy:BuildStandingsTable(sort_by)
 	if (sort_by == L["Rank"]) then sort_column = 8; end
     if (sort_by == L["Name"]) then sort_column = 1; end
 	local sort_func = function(a,b)
+		local a3 = a[3] or 0
+		local a4 = a[4] or 0
+		local b3 = b[3] or 0
+		local b4 = b[4] or 0
         if sort_column == 1 then return a[1] < b[1] end
 		if sort_column == 4 then
-            local c = a[4]-a[3]
+            local c = a4-a3
             if c < 0 then c = 0 end
-            local d = b[4]-b[3]
+            local d = b4-b3
             if d < 0 then d = 0 end
             return c > d 
         end
         if sort_column == -1 then
-            local c = a[4]-a[3]
+            local c = a4-a3
             if c < 0 then
-                c = a[3]
+                c = a3
             else
-                c = a[4]
+                c = a4
             end
-            local d = b[4]-b[3]
+            local d = b4-b3
             if d < 0 then
-                d = b[3]
+                d = b3
             else
-                d = b[4]
+                d = b4
             end
             return c > d
         end

--- a/honorspy.toc
+++ b/honorspy.toc
@@ -18,6 +18,7 @@
 Libs\embeds.xml
 Localizations\embeds.xml
 
+utils.lua
 honorspy.lua
 GUI.lua
 settings.lua

--- a/utils.lua
+++ b/utils.lua
@@ -1,0 +1,49 @@
+HonorSpyUtils = {}
+
+function HonorSpyUtils:getFullUnitName(unit)
+
+    if (unit == "player") then
+        return UnitName("player") .. "-" .. GetRealmName()
+    end
+
+    local name, realm = UnitFullName(unit)
+
+    if (name == nil) then
+        return nil
+    end
+
+    if (realm == nil) then
+        realm = GetRealmName()
+    end
+
+    return name .. "-" .. realm, name, realm
+end
+
+function HonorSpyUtils:getDisplayName(playerName)
+
+    local name, realm = HonorSpyUtils:splitNameAndServer(playerName)
+
+    if (realm == GetRealmName() or realm == nil) then
+        return name
+    end
+
+    return playerName
+end
+
+function HonorSpyUtils:getRealmFromFullUnitName(playerName)
+    return select(2, HonorSpyUtils:splitNameAndServer(playerName))
+end
+
+function HonorSpyUtils:getCompleteName(playerName)
+    local name, realm = HonorSpyUtils:splitNameAndServer(playerName)
+
+    if (realm == nil) then
+        return name .. '-' .. GetRealmName()
+    end
+
+    return playerName
+end
+
+function HonorSpyUtils:splitNameAndServer(playerName)
+    return strsplit('-', playerName)
+end


### PR DESCRIPTION
In order to make HS data more consistent over connected servers and logic more simple, mostly on coms.
May also solve / help simplify debug for the two duplicate/other server player issues we are dealing with.

I also removed the uft8.lower calls to avoid the reported crash from curse. (https://www.curseforge.com/wow/addons/honorspy?comment=434)

As playername won't be the same and sync works differently, I bumped the com prefix again