### PR TITLE
Broadcast player on any honor gain

### DIFF
--- a/honorspy.lua
+++ b/honorspy.lua
@@ -293,10 +293,10 @@ end
 -- this is called after eventg	ww
 local function CHAT_MSG_COMBAT_HONOR_GAIN_FILTER(_s, e, msg, ...)
 	local victim, est_honor, awarded_honor = parseHonorMessage(msg)
+	C_Timer.After(1, HonorSpy.CheckNeedReset) -- At this point, GetPVPSessionStats() hasn't always yet updated with the new HK
 	if (not victim) then
 		return
 	end
-    C_Timer.After(1, HonorSpy.CheckNeedReset) -- At this point, GetPVPSessionStats() hasn't always yet updated with the new HK
 	return false, format("%s kills: %d, honor: |cff00FF96%d", msg, HonorSpy.db.char.today_kills[victim] or 0, est_honor), ...
 end
 


### PR DESCRIPTION
Not sure why it's not the case, changing this will broadcast when players turn in BG marks.
Maybe there is a reason to not do it, if so please enlighten me !