### PR TITLE
Fix bug prevent realms containing spaces in their name from being stored

### DIFF
--- a/honorspy.toc
+++ b/honorspy.toc
@@ -8,7 +8,7 @@
 
 ## Author: kakysha
 ## OptionalDeps: Ace3
-## Version: 1.8.7
+## Version: 1.8.8
 
 ## X-Category: Battlegrounds/PvP
 ## SavedVariables: HonorSpyDB

--- a/utils.lua
+++ b/utils.lua
@@ -15,6 +15,8 @@ function HonorSpyUtils:getFullUnitName(unit)
     if (realm == nil) then
         realm = GetRealmName()
     end
+    
+    realm = realm:gsub(" ", "")
 
     return name .. "-" .. realm, name, realm
 end


### PR DESCRIPTION
I've fixed it by removing the spaces rather than accounting for them, since the name needs to match the /who name anyway, and the /who name removes spaces.