### PR TITLE
Fix realm names containing spaces from showing the realm name on the UI

### DIFF
--- a/utils.lua
+++ b/utils.lua
@@ -25,7 +25,7 @@ function HonorSpyUtils:getDisplayName(playerName)
 
     local name, realm = HonorSpyUtils:splitNameAndServer(playerName)
 
-    if (realm == GetRealmName() or realm == nil) then
+    if (realm == (GetRealmName():gsub(" ", "")) or realm == nil) then
         return name
     end
 


### PR DESCRIPTION
I'll leave it to Silvo to bump the TOC when he is done with other fixes.