### PR TITLE
Invalidate player data older than last_reset

### DIFF
--- a/honorspy.lua
+++ b/honorspy.lua
@@ -44,7 +44,7 @@ local function class_exist(className)
 end
 
 local function playerIsValid(player)
-	if (not player.last_checked or type(player.last_checked) ~= "number"-- or player.last_checked < HonorSpy.db.char.last_reset + 24*60*60
+	if (not player.last_checked or type(player.last_checked) ~= "number" or player.last_checked < HonorSpy.db.char.last_reset
 		or player.last_checked > GetServerTime()
 		or not player.thisWeekHonor or type(player.thisWeekHonor) ~= "number" or player.thisWeekHonor == 0
 		or not player.lastWeekHonor or type(player.lastWeekHonor) ~= "number"


### PR DESCRIPTION
This will prevent player with an old database to broadcast it to player that already performed their HS weekly reset

Related to #209