### PR TITLE
Change time of EU reset to match server restart

### DIFF
--- a/honorspy.lua
+++ b/honorspy.lua
@@ -746,7 +746,7 @@ local function getResetTime()
 	local currentUnixTime = GetServerTime()
 	local regionId = GetCurrentRegion()
 	local resetDay = 3 -- wed
-	local resetHour = 7 -- 7 AM UTC
+	local resetHour = 3 -- 7 AM UTC
 
 	if (regionId == 1) then -- US + BR + Oceania: 3 PM UTC Tue (7 AM PST Tue)
 		resetDay = 2


### PR DESCRIPTION
Related to https://github.com/kakysha/HonorSpy/issues/209

The restart is actually 9AM french time. This is quite late.
As the serveur restarts about 3AM, we could reset anyone login in after that.

Not fully confident about russia as it's not on the same time (is server time the same as EU/FR ?.)